### PR TITLE
Enable readOnlyRootFilesystem for kubectl container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Set `readOnlyRootFilesystem: true` for kubectl container.
+
 ## [0.7.0] - 2023-12-12
 
 ### Changed

--- a/helm/kubectl-apply-job/Chart.yaml
+++ b/helm/kubectl-apply-job/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: |
   A Helm chart containing a Job to apply kubernetes manifests using kubectl apply.
 name: kubectl-apply-job
-version: 0.7.0
+version: 0.8.0
 home: https://github.com/giantswarm/kubectl-apply-job
 type: library

--- a/helm/kubectl-apply-job/templates/_job.yaml
+++ b/helm/kubectl-apply-job/templates/_job.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     # create hook dependencies in the right order
     "helm.sh/hook-weight": "-1"
-    "ignore-check.kube-linter.io/no-read-only-root-fs": "kubectl writes temporary files"
     {{- include "applyJob.annotations" . | nindent 4 }}
   labels:
     {{- include "applyJob.defaultLabels" . | nindent 4 }}
@@ -58,6 +57,7 @@ spec:
         {{ end -}}
         resources: {{- (include "applyJob.resources" .) | nindent 10 }}
         securityContext:
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
This PR enables `readOnlyRootFilesystem: true` for the kubectl container. This will make it comply fully to PSS restricted profile.