### PR TITLE
Allow filenames with dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow filenames with dots.
+
 ## [0.9.1] - 2025-02-18
 
 ### Added

--- a/helm/kubectl-apply-job/templates/_configmap.yaml
+++ b/helm/kubectl-apply-job/templates/_configmap.yaml
@@ -6,7 +6,7 @@
 {{- range .Values.kubectlApplyJob.files }}
 {{- $fileName := base . -}}
 {{- $baseName := trimSuffix (ext $fileName) $fileName -}}
-{{- $cmName := printf "%s-%s" $jobName $baseName | replace "+" "_" | trunc 63 | trimSuffix "-" | lower -}}
+{{- $cmName := printf "%s-%s" $jobName $baseName | replace "." "-" | replace "+" "-" | trunc 63 | trimSuffix "-" | lower -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/kubectl-apply-job/templates/_job.yaml
+++ b/helm/kubectl-apply-job/templates/_job.yaml
@@ -50,7 +50,7 @@ spec:
         {{ range .Values.kubectlApplyJob.files }}
         {{- $fileName := base . -}}
         {{- $baseName := trimSuffix (ext $fileName) $fileName -}}
-        {{- $cmName := printf "%s-%s" $jobName $baseName | replace "+" "_" | trunc 63 | trimSuffix "-" | lower -}}
+        {{- $cmName := printf "%s-%s" $jobName $baseName | replace "." "-" | replace "+" "-" | trunc 63 | trimSuffix "-" | lower -}}
         - name: {{ $cmName | quote }}
           mountPath: {{ printf "/data/%s" $fileName | quote }}
           subPath: {{ $fileName | quote }}
@@ -73,7 +73,7 @@ spec:
       {{ range .Values.kubectlApplyJob.files }}
       {{- $fileName := base . -}}
       {{- $baseName := trimSuffix (ext $fileName) $fileName -}}
-      {{- $cmName := printf "%s-%s" $jobName $baseName | replace "+" "_" | trunc 63 | trimSuffix "-" | lower -}}
+      {{- $cmName := printf "%s-%s" $jobName $baseName | replace "." "-" | replace "+" "-" | trunc 63 | trimSuffix "-" | lower -}}
       - name: {{ $cmName | quote }}
         configMap:
           name: {{ $cmName | quote }}


### PR DESCRIPTION
This PR changes the helm templates so that file names can include a dot (`.`)