### PR TITLE
Trim '.' from .Chart.Name and .Chart.Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Trim "." from .Chart.Name and .Chart.Version in templates
+
 ## [0.11.1] - 2026-05-27
 
 ### Changed

--- a/helm/kubectl-apply-job/templates/_helpers.tpl
+++ b/helm/kubectl-apply-job/templates/_helpers.tpl
@@ -72,12 +72,12 @@ limits:
 
 {{/* Create a default fully qualified app name. Truncated to meet DNS naming spec. */}}
 {{- define "applyJob.name" -}}
-{{- printf "%s-%s" .Chart.Name (include "applyJob.jobNameSuffix" .) | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (.Chart.Name | trimSuffix "-" | trimSuffix ".") (include "applyJob.jobNameSuffix" .) | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Create chart name and version as used by the chart label. */}}
 {{- define "applyJob.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (.Chart.Name | trimSuffix "-" | trimSuffix ".") (.Chart.Version | trimSuffix "-" | trimSuffix ".") | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "applyJob.defaultLabels" -}}


### PR DESCRIPTION
Prevents errors with trimmed names and version ending in "."