### PR TITLE
chore: remove `skip_conftest_deprek8ion` from push-to-app-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ workflows:
         app_catalog_test: giantswarm-playground-test-catalog
         chart: kubectl-apply-job
         executor: app-build-suite
-        skip_conftest_deprek8ion: true
           # Trigger job on git tag.
         filters:
           tags:


### PR DESCRIPTION
`skip_conftest_deprek8ion` has been **ignored by architect-orb since v6.3.2** — passing it currently does nothing.

It is removed in the upcoming **architect-orb v10.0.0**. Because CircleCI fails config compilation on unknown job arguments, any repo still passing it will break the moment Renovate bumps the orb to v10. Merging this beforehand makes that bump a no-op for you.

No behaviour change: the parameter is already a no-op today.

Part of giantswarm/roadmap#4066