### PR TITLE
chore: drop the HelmTemplateValidator workaround

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -5,4 +5,3 @@ generate-metadata: true
 destination: ./build
 catalog-base-url: https://giantswarm.github.io/giantswarm-playground-catalog/
 disable-giantswarm-helm-validator: true
-disable-helm-template-validator: true


### PR DESCRIPTION
`kubectl-apply-job` is a `type: library` chart. app-build-suite 2.2.0 added a `HelmTemplateValidator` step that ran `helm template` unconditionally, and helm refuses library charts outright:

```
Error: library charts are not installable
```

So `disable-helm-template-validator: true` was added here to keep builds green.

That's fixed properly upstream now — giantswarm/app-build-suite#582 makes the validator skip library charts automatically, released in **abs v2.3.0**. This repo picked it up via #186 (architect orb → v10.0.0, which ships `app-build-suite:2.3.0-circleci`), so the workaround is redundant.

Verified in the published image:

```
$ docker run --rm --entrypoint sh gsoci.azurecr.io/giantswarm/app-build-suite:2.3.0-circleci -c '…'
library-chart skip: True
```

The build should now skip the step by itself, logging:

```
Chart is a library chart and cannot be rendered by 'helm template'; skipping.
```

Worth watching the `push-to-app-catalog` job on this PR — that log line is the real confirmation that the upstream fix works end to end, which is the point of removing the flag rather than leaving it.

`disable-giantswarm-helm-validator` is left alone; it's unrelated and predates this.

Part of giantswarm/roadmap#4066